### PR TITLE
Use Throwable and fixed throws annotation

### DIFF
--- a/src/ORM/TransactionMiddleware.php
+++ b/src/ORM/TransactionMiddleware.php
@@ -3,9 +3,9 @@ namespace League\Tactician\Doctrine\ORM;
 
 use Doctrine\ORM\EntityManagerInterface;
 use League\Tactician\Command;
-use Error;
 use Exception;
 use League\Tactician\Middleware;
+use Throwable;
 
 /**
  * Wraps command execution inside a Doctrine ORM transaction
@@ -31,7 +31,7 @@ class TransactionMiddleware implements Middleware
      * @param object $command
      * @param callable $next
      * @return mixed
-     * @throws Exception
+     * @throws Throwable
      */
     public function execute($command, callable $next)
     {
@@ -46,7 +46,7 @@ class TransactionMiddleware implements Middleware
             $this->entityManager->close();
             $this->entityManager->rollback();
             throw $e;
-        } catch (Error $e) {
+        } catch (Throwable $e) {
             $this->entityManager->close();
             $this->entityManager->rollback();
             throw $e;

--- a/tests/ORM/TransactionMiddlewareTest.php
+++ b/tests/ORM/TransactionMiddlewareTest.php
@@ -3,7 +3,7 @@ namespace League\Tactician\Doctrine\ORM\Tests;
 
 use Doctrine\ORM\EntityManagerInterface;
 use League\Tactician\Doctrine\ORM\TransactionMiddleware;
-use Error
+use Error;
 use Exception;
 use Mockery;
 use Mockery\MockInterface;


### PR DESCRIPTION
This is the best for forwards compatibility. Anything that's throwable needs catching. There's no reason to assume Exception and Error are the only base cases to implement Throwable.