### PR TITLE
Introduce RollbackOnlyTransactionMiddleware for ORM

### DIFF
--- a/src/ORM/RollbackOnlyTransactionMiddleware.php
+++ b/src/ORM/RollbackOnlyTransactionMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace League\Tactician\Doctrine\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use League\Tactician\Middleware;
+use Throwable;
+
+class RollbackOnlyTransactionMiddleware implements Middleware
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Executes the given command and optionally returns a value
+     *
+     * @param object $command
+     * @param callable $next
+     * @return mixed
+     * @throws \Throwable
+     * @throws \Exception
+     */
+    public function execute($command, callable $next)
+    {
+        $this->entityManager->beginTransaction();
+
+        try {
+            $returnValue = $next($command);
+
+            $this->entityManager->flush();
+            $this->entityManager->commit();
+        } catch (Exception $e) {
+            $this->entityManager->rollback();
+
+            throw $e;
+        } catch (Throwable $e) {
+            $this->entityManager->rollback();
+
+            throw $e;
+        }
+
+        return $returnValue;
+    }
+}

--- a/tests/ORM/RollbackOnlyTransactionMiddlewareTest.php
+++ b/tests/ORM/RollbackOnlyTransactionMiddlewareTest.php
@@ -1,0 +1,91 @@
+<?php
+namespace League\Tactician\Doctrine\ORM\Tests;
+
+use Doctrine\ORM\EntityManagerInterface;
+use League\Tactician\Doctrine\ORM\RollbackOnlyTransactionMiddleware;
+use League\Tactician\Doctrine\ORM\TransactionMiddleware;
+use Error;
+use Exception;
+use Mockery;
+use Mockery\MockInterface;
+use stdClass;
+
+class RollbackOnlyTransactionMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EntityManagerInterface|MockInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var RollbackOnlyTransactionMiddleware
+     */
+    private $middleware;
+
+    protected function setUp()
+    {
+        $this->entityManager = Mockery::mock(EntityManagerInterface::class);
+
+        $this->middleware = new RollbackOnlyTransactionMiddleware($this->entityManager);
+    }
+
+    public function testCommandSucceedsAndTransactionIsCommitted()
+    {
+        $this->entityManager->shouldReceive('beginTransaction')->once();
+        $this->entityManager->shouldReceive('commit')->once();
+        $this->entityManager->shouldReceive('flush')->once();
+        $this->entityManager->shouldNotReceive('rollback');
+        $this->entityManager->shouldNotReceive('close');
+
+        $executed = 0;
+        $next = function () use (&$executed) {
+            $executed++;
+        };
+
+        $this->middleware->execute(new stdClass(), $next);
+
+        $this->assertEquals(1, $executed);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage CommandFails
+     */
+    public function testCommandFailsOnExceptionAndTransactionIsRolledBack()
+    {
+        $this->entityManager->shouldReceive('beginTransaction')->once();
+        $this->entityManager->shouldReceive('commit')->never();
+        $this->entityManager->shouldReceive('flush')->never();
+        $this->entityManager->shouldReceive('rollback')->once();
+        $this->entityManager->shouldNotReceive('getConnection');
+        $this->entityManager->shouldNotReceive('close');
+
+        $next = function () {
+            throw new Exception('CommandFails');
+        };
+
+        $this->middleware->execute(new stdClass(), $next);
+    }
+
+    /**
+     * @requires PHP 7
+     *
+     * @expectedException Error
+     * @expectedExceptionMessage CommandFails
+     */
+    public function testCommandFailsOnErrorAndTransactionIsRolledBack()
+    {
+        $this->entityManager->shouldReceive('beginTransaction')->once();
+        $this->entityManager->shouldReceive('commit')->never();
+        $this->entityManager->shouldReceive('flush')->never();
+        $this->entityManager->shouldReceive('rollback')->once();
+        $this->entityManager->shouldNotReceive('getConnection');
+        $this->entityManager->shouldNotReceive('close');
+
+        $next = function () {
+            throw new Error('CommandFails');
+        };
+
+        $this->middleware->execute(new stdClass(), $next);
+    }
+}


### PR DESCRIPTION
According to https://github.com/thephpleague/tactician-doctrine/issues/18#issuecomment-370148370 extracted rollback-only behavior as a separate middleware.