### PR TITLE
add PingConnectionMiddleware to reconnect in case the connection expires

### DIFF
--- a/src/DBAL/PingConnectionMiddleware.php
+++ b/src/DBAL/PingConnectionMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace League\Tactician\Doctrine\DBAL;
+
+use Doctrine\DBAL\Connection;
+use League\Tactician\Middleware;
+
+/**
+ * Verifies if there is a connection established with the database. If not it will reconnect.
+ */
+final class PingConnectionMiddleware implements Middleware
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Reconnects to the database if the connection is expired.
+     *
+     * @param object $command
+     * @param callable $next
+     * @return mixed
+     */
+    public function execute($command, callable $next)
+    {
+        if (!$this->connection->ping()) {
+            $this->connection->close();
+            $this->connection->connect();
+        }
+        
+        return $next($command);
+    }
+}

--- a/tests/DBAL/PingConnectionMiddlewareTest.php
+++ b/tests/DBAL/PingConnectionMiddlewareTest.php
@@ -7,10 +7,9 @@ use League\Tactician\Doctrine\DBAL\PingConnectionMiddleware;
 use League\Tactician\Doctrine\DBAL\TransactionMiddleware;
 use Mockery;
 use Mockery\MockInterface;
-use PHPUnit\Framework\TestCase;
 use stdClass;
 
-final class PingConnectionMiddlewareTest extends TestCase
+final class PingConnectionMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Connection|MockInterface

--- a/tests/DBAL/PingConnectionMiddlewareTest.php
+++ b/tests/DBAL/PingConnectionMiddlewareTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace League\Tactician\Doctrine\DBAL\Tests;
+
+use Doctrine\DBAL\Connection;
+use League\Tactician\Doctrine\DBAL\PingConnectionMiddleware;
+use League\Tactician\Doctrine\DBAL\TransactionMiddleware;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class PingConnectionMiddlewareTest extends TestCase
+{
+    /**
+     * @var Connection|MockInterface
+     */
+    private $connection;
+
+    /**
+     * @var TransactionMiddleware
+     */
+    private $middleware;
+
+    protected function setUp()
+    {
+        $this->connection = Mockery::mock(Connection::class);
+
+        $this->middleware = new PingConnectionMiddleware($this->connection);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReconnectIfConnectionExpires()
+    {
+        $this->connection->shouldReceive('ping')->once()->andReturn(false);
+        $this->connection->shouldReceive('close')->once();
+        $this->connection->shouldReceive('connect')->once();
+
+        $executed = 0;
+        $next = function () use (&$executed) {
+            $executed++;
+        };
+
+        $this->middleware->execute(new stdClass(), $next);
+        
+        $this->assertEquals(1, $executed);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotReconnectIfConnectionIsStillAlive()
+    {
+        $this->connection->shouldReceive('ping')->once()->andReturn(true);
+        $this->connection->shouldReceive('close')->never();
+        $this->connection->shouldReceive('connect')->never();
+
+        $executed = 0;
+        $next = function () use (&$executed) {
+            $executed++;
+        };
+
+        $this->middleware->execute(new stdClass(), $next);
+
+        $this->assertEquals(1, $executed);
+    }
+}


### PR DESCRIPTION
This is used specially in workers, where if you dont do queries to the database for more than 8 hours, the connection expires. This middleware will reconnect in case that happens

Closes #24 