### PR TITLE
Group multiple catch's in one line

### DIFF
--- a/src/DBAL/TransactionMiddleware.php
+++ b/src/DBAL/TransactionMiddleware.php
@@ -38,11 +38,7 @@ class TransactionMiddleware implements Middleware
             $returnValue = $next($command);
 
             $this->connection->commit();
-        } catch (Exception $exception) {
-            $this->connection->rollBack();
-
-            throw $exception;
-        } catch (Throwable $exception) {
+        } catch (Exception | Throwable $exception) {
             $this->connection->rollBack();
 
             throw $exception;

--- a/src/ORM/RollbackOnlyTransactionMiddleware.php
+++ b/src/ORM/RollbackOnlyTransactionMiddleware.php
@@ -36,11 +36,7 @@ class RollbackOnlyTransactionMiddleware implements Middleware
 
             $this->entityManager->flush();
             $this->entityManager->commit();
-        } catch (Exception $e) {
-            $this->entityManager->rollback();
-
-            throw $e;
-        } catch (Throwable $e) {
+        } catch (Exception | Throwable $e) {
             $this->entityManager->rollback();
 
             throw $e;

--- a/src/ORM/TransactionMiddleware.php
+++ b/src/ORM/TransactionMiddleware.php
@@ -39,11 +39,7 @@ class TransactionMiddleware implements Middleware
 
             $this->entityManager->flush();
             $this->entityManager->commit();
-        } catch (Exception $e) {
-            $this->rollbackTransaction();
-
-            throw $e;
-        } catch (Throwable $e) {
+        } catch (Exception | Throwable $e) {
             $this->rollbackTransaction();
 
             throw $e;


### PR DESCRIPTION
Since PHP 7.1 we can group the exceptions: https://wiki.php.net/rfc/multiple-catch